### PR TITLE
Element value without fa class in Object Return

### DIFF
--- a/fields/acf-font-awesome-v5.php
+++ b/fields/acf-font-awesome-v5.php
@@ -300,7 +300,7 @@ if ( ! class_exists( 'acf_field_font_awesome' ) ) :
 
 					case 'object':
 						$object_data = array(
-							'element' => '<i class="' . $value . '" aria-hidden="true"></i>',
+							'element' => ( version_compare( ACFFA_MAJOR_VERSION, 5, '<' ) ) ? '<i class="fa ' . $value . '" aria-hidden="true"></i>' : '<i class="' . $value . '" aria-hidden="true"></i>',
 							'class' => $value,
 							'hex' => $icon['hex'],
 							'unicode' => $icon['unicode']


### PR DESCRIPTION
When Return value is set to Object, and FontAwesome is set to v4, it's return element without fa class.