### PR TITLE
Fixed deprecated warnings in PHP 8

### DIFF
--- a/acf-font-awesome.php
+++ b/acf-font-awesome.php
@@ -4,7 +4,7 @@
 Plugin Name: Advanced Custom Fields: Font Awesome
 Plugin URI: https://wordpress.org/plugins/advanced-custom-fields-font-awesome/
 Description: Adds a new 'Font Awesome Icon' field to the popular Advanced Custom Fields plugin.
-Version: 3.1.1
+Version: 3.1.2
 Author: mattkeys
 Author URI: http://mattkeys.me/
 License: GPLv2 or later

--- a/admin/class-ACFFA-Admin.php
+++ b/admin/class-ACFFA-Admin.php
@@ -518,7 +518,7 @@ class ACFFA_Admin
 		update_option( 'ACFFA_custom_icon_sets_list', $icon_sets_list, false );
 	}
 
-	private function remove_icon_set( $custom_icon_sets_list = false, $icon_set_name, $list_only = false )
+	private function remove_icon_set( $custom_icon_sets_list, $icon_set_name, $list_only = false )
 	{
 		if ( ! $custom_icon_sets_list ) {
 			$custom_icon_sets_list = get_option( 'ACFFA_custom_icon_sets_list' );

--- a/assets/inc/class-ACFFA-Loader-5.php
+++ b/assets/inc/class-ACFFA-Loader-5.php
@@ -276,8 +276,11 @@ class ACFFA_Loader_5
 		return $icons;
 	}
 
-	public function get_prefix( $prefix = 'far', $style )
+	public function get_prefix( $prefix, $style )
 	{
+
+		$prefix = $prefix ?: 'far';
+
 		switch ( $style ) {
 			case 'solid':
 				$prefix = 'fas';
@@ -304,8 +307,11 @@ class ACFFA_Loader_5
 		return $prefix;
 	}
 
-	public function get_prefix_label( $label = 'Regular', $prefix )
+	public function get_prefix_label( $label, $prefix )
 	{
+
+		$label = $label ?: 'Regular';
+
 		switch ( $prefix ) {
 			case 'fas':
 				$label = __( 'Solid', 'acf-font-awesome' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mattkeys
 Tags: Advanced Custom Fields, ACF, Font Awesome, FontAwesome
 Requires at least: 3.5
-Tested up to: 5.6
+Tested up to: 5.7.2
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -50,6 +50,9 @@ This ACF field type is compatible with:
 2. Searchable list of all icons, including large live preview
 
 == Changelog ==
+
+= 3.1.2 =
+* Fixed deprecated warnings in PHP 8.
 
 = 3.1.1 =
 * Fixed bug where Duotone icons were not available to existing users of this plugin due to cached versions of the icons from before this plugin could properly parse the duotone icons.


### PR DESCRIPTION
- Deprecated: Required parameter $icon_set_name follows optional parameter $custom_icon_sets_list in /admin/class-ACFFA-Admin.php on line 521
- Deprecated: Required parameter $style follows optional parameter $prefix in /assets/inc/class-ACFFA-Loader-5.php on line 279
-  Deprecated: Required parameter $prefix follows optional parameter $label in /assets/inc/class-ACFFA-Loader-5.php on line 307